### PR TITLE
Review pass: shared-dataset field collision, a broken promise, and stale refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ that session. So far:
   Instrumentation with OTel
 - [`session-2-feedback-loops/`](session-2-feedback-loops) — Observability Connects Code
   to Delivery
+- [`session-3-business-case/`](session-3-business-case) — The Business Case and
+  the Investment Diagnostic
 
 ## Delivery model
 

--- a/masterclass-curriculum-45min.md
+++ b/masterclass-curriculum-45min.md
@@ -50,7 +50,7 @@ You don't need all of them on day one. Chapter 4's principle: fast and close to 
 
 ### Async lab (self-serve)
 
-Two parts, do them in order. First, load the sample dataset and reconstruct one trace three ways: a count of error events, a filtered list of slow spans, and a waterfall; feel the difference between "I can count this" and "I can interrogate this." Second, clone the sample Go or Python service, turn on auto-instrumentation, confirm spans arrive, then add one custom span with three attributes from the four categories and verify it by querying for it. Stretch goal: have an AI assistant scaffold instrumentation for a second endpoint, then review and correct its attribute choices against the session's conventions.
+Two parts, do them in order. First, load the sample dataset and reconstruct one trace three ways: a count of error events, a filtered list of slow spans, and a waterfall; feel the difference between "I can count this" and "I can interrogate this." Second, clone the sample Go service, turn on auto-instrumentation, confirm spans arrive, then add one custom span with three attributes from the four categories and verify it by querying for it. Stretch goal: have an AI assistant scaffold instrumentation for a second endpoint, then review and correct its attribute choices against the session's conventions.
 
 ---
 

--- a/session-2-feedback-loops/cmd/seed-canary-regression/main.go
+++ b/session-2-feedback-loops/cmd/seed-canary-regression/main.go
@@ -201,8 +201,15 @@ func emit(ctx context.Context, req scenario.Request) {
 	cursor := req.Start
 	for _, step := range req.Steps {
 		end := cursor.Add(step.Duration)
+		// No duration attribute here on purpose. A span's duration is already
+		// computed from its start and end timestamps, and Honeycomb surfaces it
+		// as duration_ms — so emitting an attribute by that name shadows the
+		// real field in the one demo that is entirely about reading durations.
+		// Masterclass 1 writes into this same dataset and uses
+		// db.query.duration_ms for a genuinely distinct measurement; a second
+		// spelling of "how long did this take" is exactly the ontology drift
+		// Chapter 7 warns about.
 		_, span := tracer.Start(ctx, step.Name, trace.WithTimestamp(cursor))
-		span.SetAttributes(attribute.Int64("duration_ms", step.Duration.Milliseconds()))
 		span.End(trace.WithTimestamp(end))
 		cursor = end
 	}


### PR DESCRIPTION
A review pass across all three sessions. Three real findings plus the README omission you spotted.

## 1. Field collision on a shared dataset

MC1 and MC2 both seed **the same `sample-service` dataset**. MC2's child spans emitted a custom attribute named `duration_ms`, which:

- **shadows the span duration Honeycomb already computes** from start/end timestamps — in the one demo that is entirely about reading durations
- **disagreed with MC1's `db.query.duration_ms`** for the same logical value, on the same dataset

That's precisely the ontology drift Ch 7 warns about ("dozens of conflicting attribute keys for the same logical value"), shipped in our own teaching repo. The attribute carried nothing the span didn't already have, so it's removed. MC1 and MC2 now emit identical attribute sets.

## 2. A promise we don't keep

MC1's async lab told attendees to *"clone the sample **Go or Python** service."* There is no Python in this repo and never was — you chose Go-only at the start. Now says Go.

The Python mention on the instrumentation-traps slide stays: that names a real trap (`with_span`), it doesn't promise code.

## 3. Stale cross-reference

MC1's closing slide still pointed at MC2 by its **old** title. Fixed to match your retitle.

## 4. README

`session-3-business-case` was missing from the top-level session list. Added.

## How #1 was actually found

Worth recording, because my first attempt was wrong. Grepping the source for attribute names reported MC1 and MC2 as *lacking* `http.route` and `url.path` — false, because `semconv.HTTPRoute` and `semconv.URLPath` are function calls, not string literals.

Running all three seeders against a local OTLP receiver and diffing the resulting key sets is what surfaced the real collision. Ground truth beat reading the source.

## Checked and clean

- No broken relative links in any markdown
- Every `go run` target referenced in docs resolves
- All three session READMEs carry a pre-session checklist
- Session titles agree across the deck, curriculum, and session READMEs
- gofmt, build, vet, tests, `go mod tidy`, govulncheck (0 across all four modules), terraform fmt/validate, shellcheck

## One judgment call left for you

MC1's agenda slide has six numbered slots and still lists six topics — the new "One Word, Two Meanings" opener isn't among them, since it's framing for topic 1 rather than a topic of its own. MC3's equivalent *is* on its agenda. Adding a seventh slot to MC1 means layout surgery, so I left it; the slide's notes explain the role. Worth a look when you rehearse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)