### PR TITLE
Masterclass 1 demo: attribute before span, and register the propagator

### DIFF
--- a/session-1-fundamentals/otel-quickstart/main.go
+++ b/session-1-fundamentals/otel-quickstart/main.go
@@ -1,8 +1,17 @@
-// otel-quickstart is the Masterclass 1 live demo: a checkout service that
-// starts out auto-instrumented via otelhttp alone, then gets one hand-written
-// span added for the part auto-instrumentation can't see — the business logic
-// inside the handler. Reused as the `/api/checkout` service in later sessions
-// (e.g. Masterclass 4's SLIs).
+// otel-quickstart is the Masterclass 1 live demo, delivered in three beats:
+//
+//  1. Auto-instrumentation alone. otelhttp gives you POST /api/checkout with
+//     about a dozen attributes and no code of your own.
+//  2. One more attribute. order.id is a fact about the request, so it widens
+//     the event that already exists rather than getting its own span.
+//  3. One more span. Only once you want a duration measured separately from
+//     the request's does a second event earn its place.
+//
+// An attribute describes; a span measures. Beats 2 and 3 ship commented out so
+// `git checkout` restores the starting state and each beat is one uncomment.
+//
+// Reused as the `/api/checkout` service in later sessions (e.g. Masterclass 4's
+// SLIs).
 package main
 
 import (
@@ -19,6 +28,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -27,6 +37,8 @@ import (
 
 const serviceName = "otel-quickstart"
 
+// tracer is only needed by beat 3. It sits here uncommented so that beat is a
+// single uncomment in processOrder; an unused package-level var is legal Go.
 var tracer = otel.Tracer(serviceName)
 
 func main() {
@@ -77,18 +89,43 @@ func setupTracing(ctx context.Context) (func(context.Context) error, error) {
 		sdktrace.WithResource(res),
 	)
 	otel.SetTracerProvider(provider)
+	setupPropagation()
 
 	return provider.Shutdown, nil
 }
 
-// setRoute records http.route on the span otelhttp already created for this
-// request. otelhttp hands you about a dozen attributes for free, but not the
-// matched route template — a concrete case of Chapter 6's "always review which
-// attributes you get with automatic instrumentation, and don't settle for only
-// what your instrumentation library gives you by default." http.route is also
-// what Masterclass 4's SLI filters on, so it has to be here.
+// setupPropagation registers the W3C trace context and baggage propagators.
+//
+// Without this, otel.GetTextMapPropagator() is a no-op: an inbound traceparent
+// header is ignored and this service starts a brand-new trace instead of joining
+// the caller's. That turns one distributed trace into two disconnected ones, and
+// it fails silently — the spans still arrive and still look fine on their own.
+//
+// TraceContext is the W3C standard header pair. Baggage is what carries
+// key-value context across a service boundary, which is the mechanism behind
+// Chapter 7's async-boundary trap.
+func setupPropagation() {
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+}
+
+// enrich adds attributes to the span otelhttp already created for this request,
+// rather than starting a new one. This is the move Chapter 6 is about: widen the
+// event you already have.
+func enrich(ctx context.Context, kv ...attribute.KeyValue) {
+	trace.SpanFromContext(ctx).SetAttributes(kv...)
+}
+
+// setRoute records http.route. otelhttp hands you about a dozen attributes for
+// free, but not the matched route template — a concrete case of Chapter 6's
+// "always review which attributes you get with automatic instrumentation, and
+// don't settle for only what your instrumentation library gives you by
+// default." http.route is also what Masterclass 4's SLI filters on, so it has
+// to be here.
 func setRoute(ctx context.Context, route string) {
-	trace.SpanFromContext(ctx).SetAttributes(semconv.HTTPRoute(route))
+	enrich(ctx, semconv.HTTPRoute(route))
 }
 
 func handleHealthz(w http.ResponseWriter, r *http.Request) {
@@ -97,25 +134,34 @@ func handleHealthz(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleCheckout(w http.ResponseWriter, r *http.Request) {
-	setRoute(r.Context(), "/api/checkout")
+	ctx := r.Context()
+	setRoute(ctx, "/api/checkout")
 	orderID := newOrderID()
 
-	processOrder(r.Context(), orderID)
+	// --- BEAT 2: one more attribute. Uncomment live. ---
+	// order.id is a fact about this request, not a duration, so it widens the
+	// span otelhttp already created. Wrapping it in a child span would add a
+	// node to the trace without adding a measurement, and would split one
+	// request's context across two narrower events instead of widening one.
+	// enrich(ctx, attribute.String("order.id", orderID))
+	// --- END BEAT 2 ---
+
+	processOrder(ctx)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(map[string]string{"order_id": orderID})
 }
 
-// processOrder is where the live demo adds a custom span. otelhttp's
-// auto-instrumentation already captures the HTTP request itself; everything
-// inside this function is invisible to a trace until the block below exists.
-func processOrder(ctx context.Context, orderID string) {
-	// --- CUSTOM SPAN: added live, after showing auto-instrumentation alone ---
-	ctx, span := tracer.Start(ctx, "process_order")
-	span.SetAttributes(attribute.String("order.id", orderID))
-	defer span.End()
-	// --- END CUSTOM SPAN ---
+// processOrder is beat 3. A span here is justified where the attribute was not:
+// we want processing time as its own measurement, separate from total request
+// duration. That is the question a span answers, and the reason to pay for a
+// second event.
+func processOrder(ctx context.Context) {
+	// --- BEAT 3: one more span. Uncomment live. ---
+	// ctx, span := tracer.Start(ctx, "process_order")
+	// defer span.End()
+	// --- END BEAT 3 ---
 
 	simulateOrderProcessing(ctx)
 }

--- a/session-1-fundamentals/otel-quickstart/main.go
+++ b/session-1-fundamentals/otel-quickstart/main.go
@@ -146,21 +146,27 @@ func handleCheckout(w http.ResponseWriter, r *http.Request) {
 	// enrich(ctx, attribute.String("order.id", orderID))
 	// --- END BEAT 2 ---
 
-	processOrder(ctx)
+	processOrder(ctx, orderID)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(map[string]string{"order_id": orderID})
 }
 
-// processOrder is beat 3. A span here is justified where the attribute was not:
-// we want processing time as its own measurement, separate from total request
-// duration. That is the question a span answers, and the reason to pay for a
-// second event.
-func processOrder(ctx context.Context) {
+// processOrder is beat 3. A span here is justified where the attribute alone was
+// not: we want processing time as its own measurement, separate from total
+// request duration. That is the question a span answers, and the reason to pay
+// for a second event.
+//
+// order.id goes on this span as well, because attributes do not inherit down a
+// trace. Each span is its own event, so a span you want to filter or group by
+// order has to carry order.id itself — otherwise querying order.id finds the
+// request and not the work done inside it.
+func processOrder(ctx context.Context, orderID string) {
 	// --- BEAT 3: one more span. Uncomment live. ---
 	// ctx, span := tracer.Start(ctx, "process_order")
 	// defer span.End()
+	// enrich(ctx, attribute.String("order.id", orderID))
 	// --- END BEAT 3 ---
 
 	simulateOrderProcessing(ctx)

--- a/session-1-fundamentals/otel-quickstart/main_test.go
+++ b/session-1-fundamentals/otel-quickstart/main_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// exporter is shared by every test in this package. otel's global tracer
+// delegate can be set exactly once per process, so a second TracerProvider is
+// silently ignored and its spans keep landing in the first exporter. One
+// provider, and each test takes the slice of spans its own request appended.
+var exporter *tracetest.InMemoryExporter
+
+func TestMain(m *testing.M) {
+	exporter = tracetest.NewInMemoryExporter()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter)))
+	setupPropagation()
+	os.Exit(m.Run())
+}
+
+// newHandler mirrors what main() serves, so these tests exercise the real
+// wiring rather than a copy of it that can drift.
+func newHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", handleHealthz)
+	mux.HandleFunc("POST /api/checkout", handleCheckout)
+	return otelhttp.NewHandler(mux, serviceName)
+}
+
+// spansFor drives one request through the real handler and returns only the
+// spans that request produced. Tests must not call t.Parallel: the before/after
+// slice boundary assumes sequential execution.
+func spansFor(t *testing.T, req *http.Request, wantStatus int) []tracetest.SpanStub {
+	t.Helper()
+
+	before := len(exporter.GetSpans())
+	rec := httptest.NewRecorder()
+	newHandler().ServeHTTP(rec, req)
+	if rec.Code != wantStatus {
+		t.Fatalf("%s %s returned %d, want %d", req.Method, req.URL.Path, rec.Code, wantStatus)
+	}
+
+	spans := exporter.GetSpans()[before:]
+	if len(spans) == 0 {
+		t.Fatal("no spans exported")
+	}
+	return spans
+}
+
+// TestCheckoutTraceShape pins the properties that must hold at every beat of the
+// demo, including with beats 2 and 3 still commented out as committed.
+//
+// Span count deliberately is not asserted: beat 3 legitimately adds one. What
+// must never change is where order.id lives. An attribute describing the request
+// belongs on the request's own span, so if it ever migrates onto a child this
+// fails — that is the distinction the demo teaches.
+func TestCheckoutTraceShape(t *testing.T) {
+	spans := spansFor(t, httptest.NewRequest("POST", "/api/checkout", nil), http.StatusCreated)
+
+	var roots, children []tracetest.SpanStub
+	for _, s := range spans {
+		if s.Parent.IsValid() {
+			children = append(children, s)
+		} else {
+			roots = append(roots, s)
+		}
+	}
+
+	// One root, always. A request with no inbound traceparent starts its own
+	// trace; if the request span ever gained a parent here, every trace in the
+	// dataset would render with phantom missing spans above it.
+	if len(roots) != 1 {
+		t.Fatalf("got %d root spans, want 1", len(roots))
+	}
+	root := roots[0]
+
+	// otelhttp renames the span from r.Pattern after routing. This guards
+	// against a change that reverts it to the static operation name.
+	if want := "POST /api/checkout"; root.Name != want {
+		t.Errorf("root span name = %q, want %q", root.Name, want)
+	}
+
+	rootAttrs := map[string]string{}
+	for _, kv := range root.Attributes {
+		rootAttrs[string(kv.Key)] = kv.Value.String()
+	}
+
+	// Masterclass 4's SLI filters on http.route, and otelhttp does not set it
+	// for a mux-level wrap — see setRoute.
+	if got := rootAttrs["http.route"]; got != "/api/checkout" {
+		t.Errorf("http.route on root = %q, want %q", got, "/api/checkout")
+	}
+
+	// Children are allowed (beat 3), but they must hang off the request span.
+	for _, c := range children {
+		if c.Parent.SpanID() != root.SpanContext.SpanID() {
+			t.Errorf("span %q parented to %s, want the request span %s",
+				c.Name, c.Parent.SpanID(), root.SpanContext.SpanID())
+		}
+		for _, kv := range c.Attributes {
+			if kv.Key == "order.id" {
+				t.Errorf("order.id found on child span %q; it describes the request, so it belongs on the request span", c.Name)
+			}
+		}
+	}
+
+	if _, ok := rootAttrs["order.id"]; ok {
+		t.Logf("beat 2+ state: order.id on the request span, %d child span(s)", len(children))
+	} else {
+		t.Logf("beat 1 state (as committed): auto-instrumentation only, %d child span(s)", len(children))
+	}
+}
+
+// TestInboundTraceparentIsJoined covers a failure that is invisible in the
+// resulting data: with no propagator registered, an inbound traceparent is
+// dropped and this service silently starts a second, disconnected trace rather
+// than continuing the caller's.
+func TestInboundTraceparentIsJoined(t *testing.T) {
+	const (
+		upstreamTrace = "4bf92f3577b34da6a3ce929d0e0e4736"
+		upstreamSpan  = "00f067aa0ba902b7"
+	)
+
+	req := httptest.NewRequest("POST", "/api/checkout", nil)
+	req.Header.Set("traceparent", "00-"+upstreamTrace+"-"+upstreamSpan+"-01")
+
+	var request *tracetest.SpanStub
+	for _, s := range spansFor(t, req, http.StatusCreated) {
+		if s.Name == "POST /api/checkout" {
+			request = &s
+			break
+		}
+	}
+	if request == nil {
+		t.Fatal(`no "POST /api/checkout" span found`)
+	}
+
+	if got := request.SpanContext.TraceID().String(); got != upstreamTrace {
+		t.Errorf("trace ID = %s, want the caller's %s — the inbound traceparent was not extracted, so this is a new trace", got, upstreamTrace)
+	}
+	if got := request.Parent.SpanID().String(); got != upstreamSpan {
+		t.Errorf("parent span ID = %s, want the caller's %s", got, upstreamSpan)
+	}
+	if !request.Parent.IsRemote() {
+		t.Error("parent is not marked remote; it should have come from the traceparent header")
+	}
+}

--- a/session-1-fundamentals/otel-quickstart/main_test.go
+++ b/session-1-fundamentals/otel-quickstart/main_test.go
@@ -98,22 +98,42 @@ func TestCheckoutTraceShape(t *testing.T) {
 		t.Errorf("http.route on root = %q, want %q", got, "/api/checkout")
 	}
 
-	// Children are allowed (beat 3), but they must hang off the request span.
+	rootOrderID, rootHasOrderID := rootAttrs["order.id"]
+
+	// Children are allowed (beat 3), but each must hang off the request span and
+	// carry order.id itself. Attributes do not inherit down a trace, so a child
+	// without it cannot be filtered or grouped by order — querying order.id
+	// would find the request and not the work done inside it.
 	for _, c := range children {
 		if c.Parent.SpanID() != root.SpanContext.SpanID() {
 			t.Errorf("span %q parented to %s, want the request span %s",
 				c.Name, c.Parent.SpanID(), root.SpanContext.SpanID())
 		}
+
+		var childOrderID string
+		var found bool
 		for _, kv := range c.Attributes {
 			if kv.Key == "order.id" {
-				t.Errorf("order.id found on child span %q; it describes the request, so it belongs on the request span", c.Name)
+				childOrderID, found = kv.Value.String(), true
 			}
+		}
+
+		switch {
+		case found && !rootHasOrderID:
+			t.Errorf("span %q carries order.id but the request span does not; the attribute describes the request, so it belongs there first", c.Name)
+		case rootHasOrderID && !found:
+			t.Errorf("span %q is missing order.id; attributes do not inherit, so this span cannot be sliced by order", c.Name)
+		case found && childOrderID != rootOrderID:
+			t.Errorf("span %q has order.id %q, want %q to match the request span", c.Name, childOrderID, rootOrderID)
 		}
 	}
 
-	if _, ok := rootAttrs["order.id"]; ok {
-		t.Logf("beat 2+ state: order.id on the request span, %d child span(s)", len(children))
-	} else {
+	switch {
+	case rootHasOrderID && len(children) > 0:
+		t.Logf("beat 3 state: order.id on the request span and on %d child span(s)", len(children))
+	case rootHasOrderID:
+		t.Logf("beat 2 state: order.id on the request span, no child spans")
+	default:
 		t.Logf("beat 1 state (as committed): auto-instrumentation only, %d child span(s)", len(children))
 	}
 }


### PR DESCRIPTION
## What

Reworks the `otel-quickstart` live demo and fixes a silent propagation bug, both found while verifying the demos ahead of delivery.

### Attribute before span

The demo added a child span whose only job was to carry `order.id`. That teaches the opposite of the session's thesis: a span measures how long something took, an attribute describes what happened, and `order.id` is a fact about the request rather than a duration. A child span created purely to hold it adds a node to the trace without adding a measurement, and splits one request's context across two narrower events instead of widening one.

The demo now runs in three beats:

1. **Auto** — `otelhttp` alone gives you `POST /api/checkout` and about a dozen attributes
2. **One more attribute** — `enrich(ctx, attribute.String("order.id", orderID))` on the span that already exists
3. **One more span** — only once there is a duration worth measuring separately, and it carries `order.id` as well

Beat 3 is not a retreat from beat 2. The child span exists because it measures something; it carries the attribute because **attributes don't inherit down a trace**. Each span is its own event, so a span you want to filter or group by order has to carry `order.id` itself — otherwise querying `order.id` finds the request and not the work done inside it, which is exactly the slice you want when processing time is what you're measuring.

Beats 2 and 3 ship commented out so `git checkout` restores the starting state between rehearsals. A new `enrich()` helper — which `setRoute` also uses — keeps the `attribute` import permanently live, so each beat is a plain uncomment. Previously, commenting the span lines while leaving the import active was a hard compile error, easy to hit when editing live under time pressure.

### Propagator

No `TextMapPropagator` was ever registered, so `otel.GetTextMapPropagator()` was a no-op: an inbound `traceparent` was dropped and this service started a brand-new trace instead of joining the caller's. Measured before the fix — sent trace `4bf92f35…`, got `11f7ad29…` back. Spans still arrived and still looked correct in isolation, which is what made it invisible. Now registers W3C trace context plus baggage.

## Tests

`main_test.go` is new. It deliberately does **not** assert span count, because beat 3 legitimately adds one. What it pins is the *relationship*: `order.id` must be on the request span, every child span must carry the same value, and a child may not carry it if the request span doesn't. Also covers one-root-only, the `POST /api/checkout` name (which `otelhttp` sets from `r.Pattern` after routing), `http.route` for Masterclass 4's SLI, and that any child is parented to the request span.

Verified by mutation rather than trusting a green run, at all three beats:

- a beat 3 span **without** `order.id` → `span "process_order" is missing order.id; attributes do not inherit, so this span cannot be sliced by order`
- `order.id` on the child but **not** the request span → fails
- propagator registration removed → `trace ID = f07184d7…, want the caller's 4bf92f35…`

`make verify` green across all four modules.

## Not included

`log.Fatal(http.ListenAndServe(...))` skips the deferred `shutdown`, since `log.Fatal` calls `os.Exit`, so the final flush never runs and queued spans are dropped at exit. Left alone deliberately — fixing it properly wants `signal.NotifyContext`, which changes the shape of a `main()` that gets read aloud on stage.

Slide 9 and its speaker notes have been updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)