### PR TITLE
Review pass: two more stale references in session 4 and the curriculum

### DIFF
--- a/masterclass-curriculum-45min.md
+++ b/masterclass-curriculum-45min.md
@@ -195,4 +195,4 @@ Pick whichever domain is closest to your work and instrument one thing: a single
 
 When CI/CD, frontend, backend, and AI systems all emit OTel-compatible telemetry into unified storage, you get a single view of your entire delivery system. A slow build shows up in deploy frequency. A frontend error correlates with a backend trace. An LLM quality regression shows up as an SLO burn before a customer files a ticket. That's not monitoring; that's observability as the central nervous system of how you build and operate software.
 
-**Chapter cross-reference:** MC1 → Ch 1, 3, 4, 5, 6, 7; MC2 → Ch 2, 8, 9, 10, 24, 25; MC3 → Ch 17, 23, 26, 27, 28, 31; MC4 → Ch 11, 12; MC5 → Ch 13, 14, 15, 16, 27, 29, 30; MC6 → Ch 18, 19, 20, 21, 22, 32.
+**Chapter cross-reference:** MC1 → Ch 1, 3, 4, 5, 6, 7; MC2 → Ch 2, 8, 9, 10, 24, 25; MC3 → Ch 17, 23, 26, 27, 28, 31; MC4 → Ch 11, 12; MC5 → Ch 13, 14, 15, 16, 27, 29, 30; MC6 → Ch 18, 19, 20, 21, 22.

--- a/session-4-slis-slos/internal/scenario/scenario_test.go
+++ b/session-4-slis-slos/internal/scenario/scenario_test.go
@@ -92,7 +92,7 @@ func TestGenerate_ErrorSpikeIsDemoSized(t *testing.T) {
 }
 
 // TestGenerate_OverallSLIStaysHealthy asserts the flip side: blended across
-// the whole 24h window and every user type, the SLI barely moves. That's what
+// the whole 6h window and every user type, the SLI barely moves. That's what
 // lets the session say a 28-day-baseline target wouldn't have caught this on
 // its own — only the short trailing window does.
 func TestGenerate_OverallSLIStaysHealthy(t *testing.T) {


### PR DESCRIPTION
## Summary
Two small stale-reference fixes found while reviewing session 4 (follow-up to #10, same review pass):
- `session-4-slis-slos/internal/scenario/scenario_test.go`: `TestGenerate_OverallSLIStaysHealthy`'s comment said "the whole 24h window"; the seeded window is 6h (`Config.Window` default).
- `masterclass-curriculum-45min.md`: the closing chapter cross-reference listed MC6 as covering Ch 18-22 *and 32*, but MC6's own book-mapping line only ever named 18-22. Dropped the stray 32.

## Test plan
- [x] `go test ./...` in `session-4-slis-slos` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)