### PR TITLE
Stop attributing the perf workflow's four steps to Chapter 20

### DIFF
--- a/session-6-every-domain/README.md
+++ b/session-6-every-domain/README.md
@@ -133,6 +133,9 @@ supplement, not the primary demo.
 
 **CI/CD pipelines** (10 min): show the build-P95 trigger firing (or about
 to), click into `cicd_flaky_tests` to find the one flaky test case by name.
+Then `cicd_flaky_tests_by_branch`: the same failure rate, split trunk versus
+PR branches, which is the blast-radius point — one author's problem on a PR
+branch, everyone's on the trunk.
 
 **Performance engineering** (10 min): `perf_slow_queries` ranks the bimodal
 and long-tail queries above the three fast ones — then `perf_query_heatmap`

--- a/session-6-every-domain/honeycomb-setup/README.md
+++ b/session-6-every-domain/honeycomb-setup/README.md
@@ -58,9 +58,9 @@ doesn't matter for those two.
    ~12m baseline and ~22m regressed durations).
 
 **Performance** (`*_perf.tf`):
-1. `perf_slow_queries` — P99(duration_ms) by `db.query.text`. Chapter 20 step 1.
+1. `perf_slow_queries` — P99(duration_ms) by `db.query.text`. Workflow step 1.
 2. `perf_query_heatmap` — HEATMAP(duration_ms), filtered to the bimodal
-   query. Chapter 20 step 2.
+   query. Workflow step 2.
 3. `perf_duration_by_user_type` — AVG(duration_ms) by `user.type`. Step 3.
 4. `perf_duration_amd64` / `perf_duration_arm64` — P50 and P95, filtered by
    `host.arch`. Step 4 — the whole point is that these two look the same.

--- a/session-6-every-domain/honeycomb-setup/terraform/query_perf.tf
+++ b/session-6-every-domain/honeycomb-setup/terraform/query_perf.tf
@@ -31,7 +31,7 @@ resource "honeycombio_query_annotation" "perf_slow_queries" {
   dataset     = var.perf_dataset
   query_id    = honeycombio_query.perf_slow_queries.id
   name        = "Perf: P99 duration by query"
-  description = "Chapter 20 step 1. The bimodal query (orders WHERE status) and the long-tail query (audit_log) both rank above the three fast queries — but a single P99 number can't tell you which kind of problem each one is. That's what the next query is for."
+  description = "Workflow step 1. The bimodal query (orders WHERE status) and the long-tail query (audit_log) both rank above the three fast queries — but a single P99 number can't tell you which kind of problem each one is. That's what the next query is for."
 }
 
 # Step 2: characterise the distribution. Filtered to the bimodal query found
@@ -61,7 +61,7 @@ resource "honeycombio_query_annotation" "perf_query_heatmap" {
   dataset     = var.perf_dataset
   query_id    = honeycombio_query.perf_query_heatmap.id
   name        = "Perf: duration heatmap, orders-by-status query"
-  description = "Chapter 20 step 2. Two clean bands, not a smear — a missing index on one status value, not a generally slow query. Compare against the audit_log query's heatmap, which spreads continuously instead."
+  description = "Workflow step 2. Two clean bands, not a smear — a missing index on one status value, not a generally slow query. Compare against the audit_log query's heatmap, which spreads continuously instead."
 }
 
 # Step 3: correlate with attributes.
@@ -90,7 +90,7 @@ resource "honeycombio_query_annotation" "perf_duration_by_user_type" {
   dataset     = var.perf_dataset
   query_id    = honeycombio_query.perf_duration_by_user_type.id
   name        = "Perf: AVG duration by user.type"
-  description = "Chapter 20 step 3. Enterprise accounts run measurably slower — larger accounts, more data per request."
+  description = "Workflow step 3. Enterprise accounts run measurably slower — larger accounts, more data per request."
 }
 
 # Step 4: track optimisation impact across the Graviton migration. Two
@@ -124,7 +124,7 @@ resource "honeycombio_query_annotation" "perf_duration_amd64" {
   dataset     = var.perf_dataset
   query_id    = honeycombio_query.perf_duration_amd64.id
   name        = "Perf: P50/P95 duration, amd64 (pre-migration)"
-  description = "Chapter 20 step 4, before. Compare against the arm64 query below — the whole point is that these two should look the same."
+  description = "Workflow step 4, before. Compare against the arm64 query below — the whole point is that these two should look the same."
 }
 
 data "honeycombio_query_specification" "perf_duration_arm64" {
@@ -155,5 +155,5 @@ resource "honeycombio_query_annotation" "perf_duration_arm64" {
   dataset     = var.perf_dataset
   query_id    = honeycombio_query.perf_duration_arm64.id
   name        = "Perf: P50/P95 duration, arm64 (post-migration)"
-  description = "Chapter 20 step 4, after. No regression is the finding, not the assumption — see internal/perfscenario's package comment for how the seeded data backs that up honestly."
+  description = "Workflow step 4, after. No regression is the finding, not the assumption — see internal/perfscenario's package comment for how the seeded data backs that up honestly."
 }


### PR DESCRIPTION
Two loose ends from #15, which landed while I was writing them.

**The perf workflow's four steps were attributed to Chapter 20.** The saved-query descriptions in `query_perf.tf` and `honeycomb-setup/README.md` numbered them "Chapter 20 step 1" through "step 4". The chapter doesn't enumerate those steps — it opens on a pprof flame graph and spends its length on profiling and infrastructure cost optimisation. The four-step workflow (find, characterise, correlate, track) is the session's own synthesis, and #15 sharpened the mismatch by saying exactly that in the curriculum while leaving seven "Chapter 20 step N" labels in place. Renamed to "Workflow step N", which is what the numbering always meant. This is the same misattribution class #15 existed to fix; I flagged it there and should have just done it.

**Session 6's live demo run order didn't mention the new by-branch query.** #15 seeded `vcs.ref.head.name` and added `cicd_flaky_tests_by_branch` so the CI/CD demo could show blast radius, and the curriculum and slide now promise it — but the run order, which is the thing actually read on stage, stopped at `cicd_flaky_tests`. Added the click.

No tests: comment, description-string and prose changes only, no behaviour. `gofmt -l` and `terraform fmt -check -recursive` clean, `terraform validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
